### PR TITLE
Introduce Kafka Streams processing and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Event Driven Banking
+
+Questo progetto dimostra un'architettura **event-driven** basata su Apache Kafka per la generazione e l'elaborazione di eventi in tempo reale. L'applicazione sfrutta Spring Boot insieme a **Kafka Streams** e **Spring Cloud Stream** per mostrare come implementare producer, consumer e flussi di elaborazione con resilienza e scalabilità.
+
+## Architettura
+
+- **Produttori Kafka**: inviano eventi di `TransactionEvent` e `SecurityAlertEvent` verso i relativi topic.
+- **Consumatori Kafka**: ricevono gli eventi e li elaborano in tempo reale.
+- **Kafka Streams**: un topology dedicata filtra le transazioni con importo elevato e le pubblica sul topic `high-value-transactions` applicando una logica di idempotenza tramite `KTable`.
+- **Spring Cloud Stream**: un `Consumer` gestisce gli eventi provenienti dal topic `high-value-transactions`, permettendo di scalare orizzontalmente il servizio grazie al meccanismo di gruppi di consumer.
+
+Di seguito uno schema semplificato:
+
+```
+TransactionEvent ----> [transactions topic] ----> Kafka Streams ---> [high-value-transactions topic] ---> Cloud Stream Consumer
+SecurityAlertEvent --> [security-alerts topic] --> Kafka Listener
+```
+
+## Configurazione
+
+Le principali impostazioni si trovano in `application.yml`:
+
+- `spring.kafka` definisce i parametri base di broker, producer e consumer.
+- `spring.cloud.stream` configura il binding del consumer Spring Cloud Stream verso `high-value-transactions`.
+
+Nel file `docker-compose.yml` sono disponibili i container di **Kafka** e **Zookeeper** per l'esecuzione locale.
+
+## Resilienza e idempotenza
+
+- Il topology Kafka Streams utilizza un `KTable` per memorizzare le transazioni in base al loro `transactionId`. Questo meccanismo assicura che eventi duplicati vengano sovrascritti, fornendo idempotenza.
+- Kafka garantisce la replica dei dati sui topic e, in combinazione con Kafka Streams, assicura la ripartenza in caso di fault (state store su Kafka changelog topic).
+- I consumer Spring Cloud Stream possono essere scalati su più istanze appartenenti allo stesso gruppo, sfruttando la partizionamento dei topic per la scalabilità.
+
+## Avvio del progetto
+
+1. Avviare Kafka tramite Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+2. Avviare l'applicazione Spring Boot:
+
+```bash
+./mvnw spring-boot:run
+```
+
+Durante l'avvio, lo `StartupRunner` invierà alcuni eventi di test. Nel log verranno mostrati i messaggi elaborati dalla topologia Kafka Streams e dal consumer Spring Cloud Stream.
+
+## Test
+
+Il progetto include un semplice test di caricamento del contesto e un test per la topologia Kafka Streams (`HighValueTransactionsTopologyTest`). Eseguire:
+
+```bash
+./mvnw test
+```
+

--- a/src/main/java/it/alex/kafka/banking/service/HighValueTransactionConsumer.java
+++ b/src/main/java/it/alex/kafka/banking/service/HighValueTransactionConsumer.java
@@ -1,0 +1,25 @@
+package it.alex.kafka.banking.service;
+
+import it.alex.kafka.banking.model.TransactionEvent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.function.Consumer;
+
+/**
+ * Spring Cloud Stream consumer that handles high value transactions emitted by
+ * the Kafka Streams topology.
+ */
+@Configuration
+public class HighValueTransactionConsumer {
+
+    /**
+     * Logs incoming high value transactions. Using Spring Cloud Stream allows
+     * the consumer to be easily scaled by running multiple instances in the
+     * same consumer group.
+     */
+    @Bean
+    public Consumer<TransactionEvent> highValueConsumer() {
+        return event -> System.out.println("[CloudStream] High value transaction: " + event);
+    }
+}

--- a/src/main/java/it/alex/kafka/banking/streams/KafkaStreamsTopology.java
+++ b/src/main/java/it/alex/kafka/banking/streams/KafkaStreamsTopology.java
@@ -1,0 +1,50 @@
+package it.alex.kafka.banking.streams;
+
+import it.alex.kafka.banking.model.TransactionEvent;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafkaStreams;
+import org.springframework.kafka.support.serializer.JsonSerde;
+
+/**
+ * Defines a Kafka Streams topology that filters high value transactions and
+ * outputs them to a dedicated topic. Duplicate transaction IDs are collapsed
+ * via a KTable providing a simple idempotency mechanism.
+ */
+@EnableKafkaStreams
+@Configuration
+public class KafkaStreamsTopology {
+
+    /**
+     * Builds the Kafka Streams topology. Events from the {@code transactions}
+     * topic are materialized into a KTable to remove duplicates. Transactions
+     * with amount greater than or equal to 1000 are forwarded to the
+     * {@code high-value-transactions} topic.
+     */
+    @Bean
+    public KStream<String, TransactionEvent> highValueTransactionsTopology(StreamsBuilder builder) {
+        JsonSerde<TransactionEvent> serde = new JsonSerde<>(TransactionEvent.class);
+
+        // Read stream from 'transactions' topic
+        KStream<String, TransactionEvent> input = builder.stream("transactions",
+                Consumed.with(Serdes.String(), serde));
+
+        // Materialize as table to achieve idempotency on transactionId
+        KTable<String, TransactionEvent> table = input.groupByKey()
+                .reduce((agg, val) -> val, Materialized.with(Serdes.String(), serde));
+
+        // Filter for high value transactions and send to dedicated topic
+        table.toStream()
+             .filter((key, value) -> value.getAmount() >= 1000)
+             .to("high-value-transactions", Produced.with(Serdes.String(), serde));
+
+        return input;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,16 @@ spring:
   application:
     name: event-driven-banking
 
+  cloud:
+    stream:
+      bindings:
+        highValueConsumer-in-0:
+          destination: high-value-transactions
+          group: high-value-group
+      kafka:
+        binder:
+          brokers: localhost:9092
+
   kafka:
     bootstrap-servers: localhost:9092
     consumer:

--- a/src/test/java/it/alex/kafka/banking/streams/HighValueTransactionsTopologyTest.java
+++ b/src/test/java/it/alex/kafka/banking/streams/HighValueTransactionsTopologyTest.java
@@ -1,0 +1,54 @@
+package it.alex.kafka.banking.streams;
+
+import it.alex.kafka.banking.model.TransactionEvent;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.test.TestRecord;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.support.serializer.JsonSerde;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Simple test verifying the Kafka Streams topology filters high value transactions.
+ */
+class HighValueTransactionsTopologyTest {
+
+    @Test
+    void testFiltering() {
+        KafkaStreamsTopology config = new KafkaStreamsTopology();
+        StreamsBuilder builder = new StreamsBuilder();
+        config.highValueTransactionsTopology(builder);
+        Topology topology = builder.build();
+
+        try (TopologyTestDriver driver = new TopologyTestDriver(topology)) {
+            JsonSerde<TransactionEvent> serde = new JsonSerde<>(TransactionEvent.class);
+            TestInputTopic<String, TransactionEvent> input = driver.createInputTopic(
+                    "transactions", Serdes.String().serializer(), serde.serializer());
+            TestOutputTopic<String, TransactionEvent> output = driver.createOutputTopic(
+                    "high-value-transactions", Serdes.String().deserializer(), serde.deserializer());
+
+            // send low value
+            TransactionEvent low = new TransactionEvent(UUID.randomUUID().toString(),
+                    "A1", 100, "deposit", LocalDateTime.now());
+            input.pipeInput(low.getTransactionId(), low);
+
+            // send high value
+            TransactionEvent high = new TransactionEvent(UUID.randomUUID().toString(),
+                    "A1", 1500, "deposit", LocalDateTime.now());
+            input.pipeInput(high.getTransactionId(), high);
+
+            List<TestRecord<String, TransactionEvent>> results = output.readRecordsToList();
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).value().getAmount()).isEqualTo(1500);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Kafka Streams topology to filter high value transactions
- add Spring Cloud Stream consumer for filtered transactions
- document architecture and configuration in README
- add unit test for the Kafka Streams topology
- update configuration for Cloud Stream binding

## Testing
- `mvnw test -q` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6870f3fea89c8321968baea91c82da12